### PR TITLE
improved test descriptions

### DIFF
--- a/integration_test/namesdao/namesdao_test.dart
+++ b/integration_test/namesdao/namesdao_test.dart
@@ -4,13 +4,13 @@ import 'package:test/test.dart';
 Future<void> main() async {
   final namesdaoInterface = NamesdaoApi();
 
-  test('should get name info for name', () async {
+  test('should fail getting name info for invalid name', () async {
     const name = '_namesdao.xchh';
     final nameInfo = await namesdaoInterface.getNameInfo(name);
     expect(nameInfo?.address.address, equals(null));
   });
 
-  test('should get name info for cloaked registration', () async {
+  test('should get name info for valid name ___CloakedRegistration.xch', () async {
     const name = '___CloakedRegistration.xch';
     final nameInfo = await namesdaoInterface.getNameInfo(name);
     expect(


### PR DESCRIPTION
to reduce potential confusion; have not tested, just spotted these areas for potential confusion while reviewing online ("cloaked registration" is a concept for something else in our system, we are just using this particular Namesdao .xch name as a sample name for testing purposes)